### PR TITLE
feat: Run perf suite

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ DATA_PATH=data/default/
 CERAMIC_IMAGE_TAG=latest
 CAS_IMAGE_TAG=latest
 IPFS_IMAGE_TAG=latest
+BENCHIE_IMAGE_TAG=latest
 
 # Ceramic
 CERAMIC_DAEMON_PORT=7007

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ceramic"]
 	path = submodules/ceramic
 	url = https://github.com/ceramicnetwork/js-ceramic
+[submodule "benchie"]
+	path = submodules/benchie
+	url = https://github.com/ceramicnetwork/benchie.git

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ docker-compose --env-file .env.dev-unstable up
 
 For more `docker-compose` options and start configuration visit the [official documentation](https://docs.docker.com/compose/reference/overview/).
 
+**Perf testing**
+
+To start perf testing one has to run additional `perf` service:
+```shell
+docker-compose -f docker-compose.yml -f docker-compose.perf.yml up
+```
+
+It will immediately start performance testing suite with all the tests.
+
 ### Execute commands
 
 First get the container ID for js-ceramic:

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ docker-compose --env-file .env.dev-unstable up
 
 For more `docker-compose` options and start configuration visit the [official documentation](https://docs.docker.com/compose/reference/overview/).
 
-**Perf testing**
+**Performance testing**
 
-To start perf testing one has to run additional `perf` service:
+To start performance testing one has to run additional `benchie` service:
 ```shell
-docker-compose -f docker-compose.yml -f docker-compose.perf.yml up
+docker-compose -f docker-compose.yml -f docker-compose.benchie.yml up
 ```
 
 It will immediately start performance testing suite with all the tests.

--- a/docker-compose.benchie.yml
+++ b/docker-compose.benchie.yml
@@ -1,11 +1,10 @@
 version: '3.4'
 
 services:
-  perf:
+  benchie:
     depends_on:
       - ceramic
-    build:
-      context: submodules/benchie
+    image: ceramicnetwork/benchie:${BENCHIE_IMAGE_TAG}
     environment:
       CERAMIC_ENDPOINT: "http://ceramic:${CERAMIC_DAEMON_PORT}"
       SECONDARY_CERAMIC_ENDPOINT: "https://ceramic-clay.3boxlabs.com/"

--- a/docker-compose.perf.yml
+++ b/docker-compose.perf.yml
@@ -1,0 +1,21 @@
+version: '3.4'
+
+services:
+  perf:
+    depends_on:
+      - ceramic
+    build:
+      context: submodules/benchie
+    environment:
+      CERAMIC_ENDPOINT: "http://ceramic:${CERAMIC_DAEMON_PORT}"
+      SECONDARY_CERAMIC_ENDPOINT: "https://ceramic-clay.3boxlabs.com/"
+    entrypoint: ""
+    command: >
+      /bin/bash -c "
+        apt-get update -y && apt-get install -y netcat;
+        while ! nc -z ceramic ${CERAMIC_DAEMON_PORT};
+        do
+          sleep 1;
+        done;
+        npm run start
+      "


### PR DESCRIPTION
- Add a docker-compose file with performance testing suite
- Add a note to README on how to run it

Note: It assumes, that perf-suite is built from a git submodule, not from a Docker image.

It is a question to @v-stickykeys if we should do git submodules here or run an image from https://github.com/ceramicnetwork/benchie/pull/14